### PR TITLE
Split Gain out from Delay

### DIFF
--- a/src/audio_unit/delay.rs
+++ b/src/audio_unit/delay.rs
@@ -3,13 +3,12 @@ use cpal::StreamConfig;
 use ringbuf::{Consumer, Producer, RingBuffer};
 
 pub struct Delay {
-    level: f32,
     producer: Producer<f32>,
     consumer: Consumer<f32>,
 }
 
 impl Delay {
-    pub fn new(stream_config: &StreamConfig, level: f32, delay_ms: u32) -> Result<Self> {
+    pub fn new(stream_config: &StreamConfig, delay_ms: u32) -> Result<Self> {
         let delay_num_frames = (delay_ms as f32 / 1_000.0) * stream_config.sample_rate.0 as f32;
         let delay_num_samples = delay_num_frames as usize * stream_config.channels as usize;
 
@@ -18,26 +17,14 @@ impl Delay {
 
         ring_buffer::write_empty_samples(&mut producer, delay_num_samples)?;
 
-        Ok(Self {
-            level,
-            producer,
-            consumer,
-        })
+        Ok(Self { producer, consumer })
     }
 }
 
 impl AudioUnit for Delay {
-    fn name(&self) -> String {
-        "Delay".into()
-    }
-
     fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
         ring_buffer::write_frame(&mut self.producer, input)?;
-        let samples: Vec<f32> = ring_buffer::read_frame(&mut self.consumer, output.len())?
-            .into_iter()
-            .map(|sample| sample * self.level)
-            .collect();
-
+        let samples: Vec<f32> = ring_buffer::read_frame(&mut self.consumer, output.len())?;
         output.copy_from_slice(&samples);
 
         Ok(())

--- a/src/audio_unit/gain.rs
+++ b/src/audio_unit/gain.rs
@@ -1,0 +1,21 @@
+use crate::{AudioUnit, Result};
+
+pub struct Gain {
+    gain: f32,
+}
+
+impl Gain {
+    pub fn new(gain: f32) -> Self {
+        Self { gain }
+    }
+}
+
+impl AudioUnit for Gain {
+    fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
+        for i in 0..input.len() {
+            output[i] = input[i] * self.gain;
+        }
+
+        Ok(())
+    }
+}

--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -1,21 +1,20 @@
 mod delay;
+mod gain;
 mod pipeline;
 mod split;
 mod transparent;
 
 pub use delay::Delay;
+pub use gain::Gain;
 pub use pipeline::Pipeline;
 pub use split::Split;
 pub use transparent::Transparent;
 
 use crate::Result;
-use std::fmt::Display;
 
 pub type Boxed = Box<dyn AudioUnit>;
 
 pub trait AudioUnit: Send + Sync {
-    fn name(&self) -> String;
-
     fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()>;
 
     fn boxed(self) -> Boxed
@@ -23,11 +22,5 @@ pub trait AudioUnit: Send + Sync {
         Self: 'static + Sized,
     {
         Box::new(self)
-    }
-}
-
-impl Display for dyn AudioUnit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.name(), f)
     }
 }

--- a/src/audio_unit/pipeline.rs
+++ b/src/audio_unit/pipeline.rs
@@ -1,6 +1,4 @@
-use std::fmt::Display;
-
-use crate::{audio_unit, Config, Result};
+use crate::{audio_unit, AudioUnit, Config, Result};
 use anyhow::anyhow;
 use cpal::StreamConfig;
 
@@ -14,7 +12,7 @@ impl Pipeline {
         Pipeline::new(audio_units)
     }
 
-    fn new(audio_units: Vec<audio_unit::Boxed>) -> Result<Self> {
+    pub fn new(audio_units: Vec<audio_unit::Boxed>) -> Result<Self> {
         if audio_units.is_empty() {
             Err(anyhow!("Must have at least one audio unit in the pipeline"))
         } else {
@@ -34,16 +32,8 @@ impl Pipeline {
     }
 }
 
-impl Display for Pipeline {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut names: Vec<_> = self
-            .audio_units
-            .iter()
-            .map(|audio_unit| audio_unit.name())
-            .collect();
-        names.insert(0, "Input".into());
-        names.insert(names.len(), "Output".into());
-
-        names.join(" -> ").fmt(f)
+impl AudioUnit for Pipeline {
+    fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
+        self.process(input, output)
     }
 }

--- a/src/audio_unit/split.rs
+++ b/src/audio_unit/split.rs
@@ -16,10 +16,6 @@ impl Split {
 }
 
 impl AudioUnit for Split {
-    fn name(&self) -> String {
-        "Split".into()
-    }
-
     fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
         let length = output.len();
         util::zero_slice(output);

--- a/src/audio_unit/transparent.rs
+++ b/src/audio_unit/transparent.rs
@@ -10,10 +10,6 @@ impl Transparent {
 }
 
 impl AudioUnit for Transparent {
-    fn name(&self) -> String {
-        "Transparent".into()
-    }
-
     fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
         output.copy_from_slice(input);
         Ok(())


### PR DESCRIPTION
As discussed on Slack, this breaks the pedals down into their smallest possible components, so `Delay` has been split into `Delay` and `Gain`. This required using a pipeline of components as an individual "pedal" (delay -> gain), so I made `Pipeline` implement `Pedal`.

Fixes #9. Fixes #11.