### PR TITLE
Allow setting the input/output devices in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ cargo test
 Create a configuration file for the pipeline:
 
 ```yaml
+# omit "audio" to use the defaults
+# all fields in "audio" are optional
+audio:
+  input: # put any string here to have pedals show you a list of available devices
+  output: # ditto
 midi:
   port: # put any string here to have pedals show you a list of available ports
   channel: 1

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Audio {
+    pub input: Option<String>,
+    pub output: Option<String>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,9 @@
+mod audio;
 mod effect;
 mod midi;
 
 use crate::{audio_unit, Result};
+use audio::Audio;
 use cpal::StreamConfig;
 use effect::Effect;
 use midi::Midi;
@@ -9,6 +11,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
+    pub audio: Option<Audio>,
     pub midi: Option<Midi>,
     pub effects: Vec<Effect>,
 }
@@ -20,6 +23,7 @@ impl Config {
 
     pub fn default() -> Self {
         Self {
+            audio: None,
             midi: None,
             effects: vec![Effect::Transparent],
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,14 @@ use std::{env, fs};
 
 fn main() -> Result<()> {
     let config = config()?;
-    let (input_device, output_device) = audio::devices()?;
+
+    let input_device = config
+        .audio
+        .as_ref()
+        .and_then(|audio| (&audio.input).clone());
+    let output_device = config.audio.as_ref().and_then(|audio| audio.output.clone());
+
+    let (input_device, output_device) = audio::devices(&input_device, &output_device)?;
     let stream_config = audio::config(&input_device)?;
     let pipeline = Pipeline::from(&config, &stream_config)?;
 


### PR DESCRIPTION
This lets you set the input/ouput devices in the config file. It's a little fussy on macOS if you use AirPods (old "phantom" devices will show up in the list of devices we get, but will fail once you try to build the input/output stream), but this seems to work well for "normal" audio devices. (I can use my audio interface as the input device now.)