### PR TITLE
Improve ring buffer performance

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -31,7 +31,7 @@ pub fn run(
     };
 
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
-        if let Err(e) = ring_buffer::write_frame(&mut producer, data) {
+        if let Err(e) = ring_buffer::write_samples(&mut producer, data) {
             eprintln!("input: {:?}", e);
         }
     };

--- a/src/audio_unit/delay.rs
+++ b/src/audio_unit/delay.rs
@@ -93,7 +93,7 @@ impl AudioUnit for Delay {
     fn process(&mut self, input: &[f32], output: &mut [f32]) -> Result<()> {
         self.process_messages()?;
 
-        ring_buffer::write_frame(&mut self.producer, input)?;
+        ring_buffer::write_samples(&mut self.producer, input)?;
         let samples: Vec<f32> = ring_buffer::read_samples(&mut self.consumer, output.len())?;
         output.copy_from_slice(&samples);
 


### PR DESCRIPTION
The ring buffer library has some functions for efficient reading/writing of large amounts of data, which I wasn't using. This is important for the delay audio unit, where, as the delay changes, we are reading and writing 100,000s of samples at once. I think the slowness there was the actual cause of the weird sounds when changing the delay.