### PR TITLE
Looper: overdubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ effects:
     toggle:
       channel: 1
       note: 60
+    overdub:
+      channel: 1
+      note: 61
 
 ```
 

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -150,8 +150,10 @@ impl Looper {
 
             self.state = match self.state {
                 PlayingAwaitingOverdub { .. } if next_position == total => {
+                    println!("looper: activating overdub");
                     Overdubbing { position, total }
                 }
+                PlayingAwaitingOverdub { .. } => PlayingAwaitingOverdub { position, total },
                 _ => Playing { position, total },
             }
         } else {

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -120,12 +120,11 @@ impl Looper {
                         next_position
                     };
 
-                    self.state = match next_position == total {
-                        true => {
-                            println!("looper: done overdubbing");
-                            Playing { position, total }
-                        }
-                        _ => Overdubbing { position, total },
+                    self.state = if next_position == total {
+                        println!("looper: done overdubbing");
+                        Playing { position, total }
+                    } else {
+                        Overdubbing { position, total }
                     }
                 } else {
                     self.process_samples_wrap_around(position, total, input, output);

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -120,6 +120,12 @@ impl Looper {
 
                 if next_position <= total {
                     output.copy_from_slice(&self.buffer[position..next_position]);
+
+                    for sample_number in 0..input.len() {
+                        self.buffer[position + sample_number] =
+                            self.buffer[position + sample_number] + input[sample_number];
+                    }
+
                     let position = if next_position == total {
                         0
                     } else {

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -56,18 +56,7 @@ impl Looper {
                         position: 0,
                         total: position,
                     },
-                    Playing {
-                        position: _,
-                        total: _,
-                    } => Off,
-                    PlayingAwaitingOverdub {
-                        position: _,
-                        total: _,
-                    } => Off,
-                    Overdubbing {
-                        position: _,
-                        total: _,
-                    } => Off,
+                    _ => Off,
                 };
 
                 println!("looper: {:?}", self.state);

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -6,7 +6,7 @@ use State::*;
 #[derive(Debug)]
 pub enum Message {
     Toggle,
-    ToggleOverdubMode,
+    EnableOverdubMode,
 }
 
 #[derive(Debug)]

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -121,9 +121,8 @@ impl Looper {
                 if next_position <= total {
                     output.copy_from_slice(&self.buffer[position..next_position]);
 
-                    for sample_number in 0..input.len() {
-                        self.buffer[position + sample_number] =
-                            self.buffer[position + sample_number] + input[sample_number];
+                    for (sample_number, input_sample) in input.iter().enumerate() {
+                        self.buffer[position + sample_number] += input_sample;
                     }
 
                     let position = if next_position == total {

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -6,7 +6,7 @@ use State::*;
 #[derive(Debug)]
 pub enum Message {
     Toggle,
-    EnableOverdubMode,
+    QueueOverdub,
 }
 
 #[derive(Debug)]
@@ -72,7 +72,7 @@ impl Looper {
 
                 println!("looper: {:?}", self.state);
             }
-            Message::EnableOverdubMode => {
+            Message::QueueOverdub => {
                 if let Playing { position, total } = self.state {
                     self.state = PlayingAwaitingOverdub { position, total };
 

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -98,10 +98,7 @@ impl Looper {
                     self.process_samples_wrap_around(position, self.buffer.len(), input, output);
                 }
             }
-            Playing { position, total } => {
-                self.process_samples_playing(position, total, input, output);
-            }
-            PlayingAwaitingOverdub { position, total } => {
+            Playing { position, total } | PlayingAwaitingOverdub { position, total } => {
                 self.process_samples_playing(position, total, input, output);
             }
             Overdubbing { position, total } => {

--- a/src/audio_unit/looper.rs
+++ b/src/audio_unit/looper.rs
@@ -6,6 +6,7 @@ use State::*;
 #[derive(Debug)]
 pub enum Message {
     Toggle,
+    ToggleOverdubMode,
 }
 
 #[derive(Debug)]

--- a/src/config/effect/looper.rs
+++ b/src/config/effect/looper.rs
@@ -6,6 +6,7 @@ pub struct LooperConfig {
     #[serde(default = "LooperConfig::default_loop_max")]
     pub max_ms: u32,
     pub toggle: NoteOn,
+    pub overdub: NoteOn,
 }
 
 impl LooperConfig {

--- a/src/effect/looper.rs
+++ b/src/effect/looper.rs
@@ -55,7 +55,7 @@ impl Looper {
     }
 
     fn enable_overdub_mode(&mut self) -> Result<()> {
-        Ok(self.messages.send(Message::EnableOverdubMode)?)
+        Ok(self.messages.send(Message::QueueOverdub)?)
     }
 }
 

--- a/src/effect/looper.rs
+++ b/src/effect/looper.rs
@@ -37,6 +37,12 @@ impl Looper {
                 {
                     self.toggle()?;
                 }
+                MidiMessage::NoteOn(channel, note, _)
+                    if channel == self.config.overdub.channel
+                        && note == self.config.overdub.note =>
+                {
+                    self.toggle_overdub_mode()?;
+                }
                 _ => (),
             }
         }
@@ -46,6 +52,10 @@ impl Looper {
 
     fn toggle(&mut self) -> Result<()> {
         Ok(self.messages.send(Message::Toggle)?)
+    }
+
+    fn toggle_overdub_mode(&mut self) -> Result<()> {
+        Ok(self.messages.send(Message::ToggleOverdubMode)?)
     }
 }
 

--- a/src/effect/looper.rs
+++ b/src/effect/looper.rs
@@ -41,7 +41,7 @@ impl Looper {
                     if channel == self.config.overdub.channel
                         && note == self.config.overdub.note =>
                 {
-                    self.toggle_overdub_mode()?;
+                    self.enable_overdub_mode()?;
                 }
                 _ => (),
             }
@@ -54,8 +54,8 @@ impl Looper {
         Ok(self.messages.send(Message::Toggle)?)
     }
 
-    fn toggle_overdub_mode(&mut self) -> Result<()> {
-        Ok(self.messages.send(Message::ToggleOverdubMode)?)
+    fn enable_overdub_mode(&mut self) -> Result<()> {
+        Ok(self.messages.send(Message::EnableOverdubMode)?)
     }
 }
 


### PR DESCRIPTION
Fixes #25 

In this PR:
- add ability to overdub as many additional "layers" as you want while the looper is playing back

To test:
If you update your `pipeline.yml`'s looper config to include an `overdub` `NoteOn` specification and run and create a loop using existing behavior, if you then press the overdub button/key it should start recording the input during the next time through the loop (while continuing existing playback) and then start playing back the original loop + the overdub. You should be able to repeat this to add additional overdubs. If you press the overdub button while not in loop playback mode it should ignore it